### PR TITLE
Added nano, openssh, sonar-scanner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,24 @@
 FROM java:jdk-alpine
 MAINTAINER jmeth <jmeth@users.noreply.github.com>
 
+# Install Jenkins WAR
 RUN mkdir /usr/share/jenkins && \
     wget -O /usr/share/jenkins/jenkins.war http://mirrors.jenkins-ci.org/war/latest/jenkins.war
 
+## Update, install applications, remove APK cache
 RUN apk update && \
-    apk add fontconfig ttf-dejavu git bash openssh && \
+    apk add fontconfig ttf-dejavu git bash openssh nano && \
     rm -rf /var/cache/apk/*
 
+# Install sonar-scanner to /dev/share/sonar-scanner-2.6. backup sonar-runner. rename scanenr to runn
+RUN cd /user/share && \
+    wget https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-2.6.zip && \
+    unzip sonar-scanner-2.6.zip && \
+    rm sonar-scanner-2.6.zip && \
+    mv sonar-scanner-2.6/bin/sonar-runner sonar-scanner-2.6/bin/sonar-runner.bak && \
+    cp sonar-scanner-2.6/bin/sonar-scanner sonar-scanner-2.6/bin/sonar-runner
+
+# 
 RUN MAVEN_VERSION=3.3.9 \
  && cd /usr/share \
  && wget http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz -O - | tar xzf - \


### PR DESCRIPTION
OpenSSH was needed for jenkins to use Git
Sonar-scanner is used to push code analyses and coverage over to sonarqube
Nano for alternative text editors